### PR TITLE
Get extended tweets (more than 140 chars)

### DIFF
--- a/get_tweets.py
+++ b/get_tweets.py
@@ -26,9 +26,9 @@ def get_tweets(username):
 
 	#get tweets
 	tweets_for_csv = []
-	for tweet in tweepy.Cursor(api.user_timeline, screen_name = username).items(number_of_tweets):
+	for tweet in tweepy.Cursor(api.user_timeline, screen_name = username, tweet_mode = extended).items(number_of_tweets):
         #create array of tweet information: username, tweet id, date/time, text
-		tweets_for_csv.append([username, tweet.id_str, tweet.created_at, tweet.text.encode("utf-8")])
+		tweets_for_csv.append([username, tweet.id_str, tweet.created_at, tweet.full_text.encode("utf-8")])
 
 	#write to a new csv file from the array of tweets
 	outfile = username + "_tweets.csv"


### PR DESCRIPTION
Add 'tweet_mode = extended' to 'tweepy.Cursor' call
Change 'tweet.text.encode("utf-8")' for 'tweet.full_text.encode("utf-8")' to get the full length tweet.